### PR TITLE
Update Dropwizard to latest version (1.2.2)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <revision>-SNAPSHOT</revision>
-        <dropwizard.version>0.9.2</dropwizard.version>
+        <dropwizard.version>1.2.2</dropwizard.version>
         <lombok.version>1.16.8</lombok.version>
         <mockito.version>1.10.19</mockito.version>
         <junit.version>4.12</junit.version>


### PR DESCRIPTION
I would like to update dropwizard-bundles with the latest DW version so that the latest version can also be used downstream in dropwizard-swagger